### PR TITLE
Use npm prefix in global resolver

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -2,6 +2,7 @@ var fs   = require('fs')
 var path = require('path')
 var resolve = require('resolve').sync
 var isWin32 = process.platform === 'win32'
+var rc = require('rc')
 
 'use strict';
 
@@ -79,10 +80,15 @@ function userHomeResolve(module) {
 // it uses execPath to discover node_modules based on the node binary location
 function globalResolve(module) {
   var modulePath
-  var dirname = path.dirname(process.execPath)
+  var dirname
+  var prefix
 
-  if (!isWin32) {
-    dirname = path.join(dirname, '../', 'lib')
+  if (isWin32) {
+    dirname = path.dirname(process.execPath)
+  }
+  else {
+    prefix = rc('npm').prefix || path.join(process.execPath, '../..')
+    dirname = path.join(prefix, 'lib')
   }
   dirname = path.join(dirname, 'node_modules')
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "import"
   ],
   "dependencies": {
+    "rc": "~1.0.0",
     "resolve": "~0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Global resolver does not work if custom npm prefix is set in npmrc file.

This patch fixes it by checking for prefix in npmrc. I don't know how does npm prefix work on Windows, so I limited the change to other platforms.
