### PR TITLE
Test resolution via npm prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "mocha": "~1.15.1",
     "expect.js": "~0.2.0",
+    "rewire": "~2.3.1",
     "semver": "~2.2.1"
   }
 }

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -1,4 +1,6 @@
 var expect = require('expect.js')
+var resolvers = require('rewire')('../lib/resolvers')
+require.cache[require.resolve('../lib/resolvers')] = { exports: resolvers }
 var requiregModule = require('../lib/requireg')
 
 var homeVar = process.platform === 'win32' ? 'USERPROFILE' : 'HOME'
@@ -88,13 +90,16 @@ describe('requireg', function () {
 
     describe('resolve via node execution path', function () {
       var execPath = process.execPath
+      var rc = require('rc')
 
       before(function () {
         process.execPath = __dirname + '/fixtures/bin/node'
+        resolvers.__set__('rc', function () { return {} })
       })
 
       after(function () {
         process.execPath = execPath
+        resolvers.__set__('rc', rc)
       })
 
       it('should resolve the beaker package', function () {

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -113,6 +113,32 @@ describe('requireg', function () {
 
     })
 
+    describe('resolve via npm prefix', function () {
+      var rc = require('rc')
+
+      before(function () {
+        resolvers.__set__('rc', function () {
+          return {
+            prefix: __dirname + '/fixtures'
+          }
+        })
+      })
+
+      after(function () {
+        resolvers.__set__('rc', rc)
+      })
+
+      it('should resolve the beaker package', function () {
+        expect(requiregModule('beaker')).to.be.true
+      })
+
+      it('should have the expected module path', function () {
+        expect(requiregModule.resolve('beaker'))
+          .to.be.equal(__dirname + '/fixtures/lib/node_modules/beaker/index.js')
+      })
+
+    })
+
   })
 
 })


### PR DESCRIPTION
This PR adds a test for npm prefix based resolution added in 0804ca3.

It also fixes the test for resolution via execution path to prevent it from failing if the system `.npmrc` file sets a custom npm prefix.
