### PR TITLE
fix: fix npm prefix handling on Windows

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -75,13 +75,14 @@ function userHomeResolve(module) {
 // See: https://npmjs.org/doc/files/npm-folders.html#prefix-Configuration
 // it uses execPath to discover node_modules based on the node binary location
 function globalResolve(module) {
-  var modulePath, dirname, prefix
+  var modulePath, dirname
+  var prefix = rc('npm').prefix
 
   if (isWin32) {
-    dirname = path.dirname(process.execPath)
+    dirname = prefix || path.dirname(process.execPath)
   }
   else {
-    prefix = rc('npm').prefix || path.join(process.execPath, '../..')
+    prefix = prefix || path.join(process.execPath, '../..')
     dirname = path.join(prefix, 'lib')
   }
   

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -3,7 +3,8 @@ var resolvers = require('rewire')('../lib/resolvers')
 require.cache[require.resolve('../lib/resolvers')] = { exports: resolvers }
 var requiregModule = require('../lib/requireg')
 
-var homeVar = process.platform === 'win32' ? 'USERPROFILE' : 'HOME'
+var isWin32 = process.platform === 'win32'
+var homeVar = isWin32 ? 'USERPROFILE' : 'HOME'
 var homePath = process.env[homeVar]
 
 describe('requireg', function () {
@@ -119,7 +120,7 @@ describe('requireg', function () {
       before(function () {
         resolvers.__set__('rc', function () {
           return {
-            prefix: __dirname + '/fixtures'
+            prefix: __dirname + (isWin32 ? '/fixtures/lib' : '/fixtures')
           }
         })
       })


### PR DESCRIPTION
This is the last thing from the discussion in #1.

This PR adds npm prefix support on Windows according to https://docs.npmjs.com/files/folders.
