### PR TITLE
Fix cross platform and non default prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
 test:
-	@./node_modules/.bin/mocha \
-        -u tdd \
-        --ui exports \
-        --reporter spec \
-        --slow 2000ms \
-        --bail 
+	npm test
 
 .PHONY: test

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -12,7 +12,8 @@ module.exports = [
   nodePathResolve,
   userHomeResolve,
   nodeModulesResolve,
-  globalResolve
+  prefixResolve,
+  execPathResolve
 ]
 
 function resolveFn(module, basePath, dirname) {
@@ -72,19 +73,39 @@ function userHomeResolve(module) {
 }
 
 // See: https://npmjs.org/doc/files/npm-folders.html#prefix-Configuration
-// it uses execPath to discover node_modules based on the node binary location
-function globalResolve(module) {
+// it uses execPath to discover the default prefix on *nix and %APPDATA% on Windows
+function prefixResolve(module) {
   var modulePath, dirname
   var prefix = rc('npm').prefix
 
   if (isWin32) {
-    dirname = prefix || path.dirname(process.execPath)
+    prefix = prefix || path.join(process.env.APPDATA, 'npm')
+    dirname = prefix
   }
   else {
-    prefix = prefix || path.join(process.execPath, '../..')
+    prefix = prefix || path.join(path.dirname(process.execPath), '..')
     dirname = path.join(prefix, 'lib')
   }
-  
+
+  dirname = path.join(dirname, 'node_modules')
+  modulePath = resolveFn(module, dirname)
+
+  return modulePath
+}
+
+// Resolves packages using the node installation path
+// Useful for resolving global packages such as npm when the prefix has been overriden by the user
+function execPathResolve(module) {
+  var modulePath, dirname
+  var execPath = path.dirname(process.execPath)
+
+  if (isWin32) {
+    dirname = execPath
+  }
+  else {
+    dirname = path.join(execPath, '..', 'lib')
+  }
+
   dirname = path.join(dirname, 'node_modules')
   modulePath = resolveFn(module, dirname)
 

--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -1,4 +1,4 @@
-var fs   = require('fs') 
+var fs   = require('fs')
 var path = require('path')
 var resolve = require('resolve').sync
 var rc = require('rc')
@@ -38,9 +38,8 @@ function nodePathResolve(module, dirname) {
   var nodePath = process.env.NODE_PATH
 
   if (!nodePath) { return }
-  if (isWin32) { nodePath = nodePath.replace(':', ';') }
-  
-  nodePath = nodePath.split(';').map(function (nodepath) {
+
+  nodePath = nodePath.split(path.delimiter).map(function (nodepath) {
     return path.normalize(nodepath)
   })
 
@@ -57,7 +56,7 @@ function userHomeResolve(module) {
   var i, l, modulePath
   var homePath = isWin32 ? process.env['USERPROFILE'] : process.env['HOME']
 
-  var paths = [ 
+  var paths = [
     'node_modules',
     'node_libraries',
     'node_packages'
@@ -97,13 +96,13 @@ function nodeModulesResolve(module) {
   var nodeModules = process.env['NODE_MODULES']
 
   if (typeof nodeModules === 'string') {
-    nodeModules = nodeModules.split(';')
+    nodeModules = nodeModules.split(path.delimiter)
     for (i = 0, l = nodeModules.length; i < l; i += 1) {
       if (modulePath = resolveFn(module, nodeModules[i])) {
         break;
       }
     }
   }
-  
+
   return modulePath
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "make test"
+    "test": "mocha -u tdd --ui exports --reporter spec --slow 2000ms --bail"
   },
   "keywords": [
     "global",

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 var expect = require('expect.js')
 var resolvers = require('rewire')('../lib/resolvers')
 require.cache[require.resolve('../lib/resolvers')] = { exports: resolvers }
@@ -14,7 +16,7 @@ describe('requireg', function () {
   })
 
   describe('requireg API', function () {
-    
+
     it('should globalize', function () {
       requiregModule.globalize()
       expect(requireg).to.be.a('function')
@@ -39,7 +41,7 @@ describe('requireg', function () {
     describe('resolve via NODE_PATH', function () {
 
       before(function () {
-        process.env.NODE_PATH = __dirname + '/fixtures/lib'
+        process.env.NODE_PATH = path.join(__dirname, 'fixtures', 'lib');
       })
 
       after(function () {
@@ -52,15 +54,15 @@ describe('requireg', function () {
 
       it('should have the expected module path', function () {
         expect(requiregModule.resolve('beaker'))
-          .to.be.equal(__dirname + '/fixtures/lib/node_modules/beaker/index.js')
-      }) 
+          .to.be.equal(path.join(__dirname, 'fixtures', 'lib', 'node_modules', 'beaker', 'index.js'))
+      })
 
     })
 
     describe('resolve via $HOME', function () {
 
       before(function () {
-        process.env[homeVar] = __dirname + '/fixtures/lib'
+        process.env[homeVar] = path.join(__dirname, 'fixtures', 'lib')
       })
 
       after(function () {
@@ -76,7 +78,7 @@ describe('requireg', function () {
     describe('resolve via $NODE_MODULES', function () {
 
       before(function () {
-        process.env.NODE_MODULES = __dirname + '/fixtures/lib'
+        process.env.NODE_MODULES = path.join(__dirname, 'fixtures', 'lib')
       })
 
       after(function () {
@@ -94,7 +96,7 @@ describe('requireg', function () {
       var rc = require('rc')
 
       before(function () {
-        process.execPath = __dirname + '/fixtures/bin/node'
+        process.execPath = path.join(__dirname, 'fixtures', 'lib', 'node')
         resolvers.__set__('rc', function () { return {} })
       })
 
@@ -109,7 +111,7 @@ describe('requireg', function () {
 
       it('should have the expected module path', function () {
         expect(requiregModule.resolve('beaker'))
-          .to.be.equal(__dirname + '/fixtures/lib/node_modules/beaker/index.js')
+          .to.be.equal(path.join(__dirname, 'fixtures', 'lib', 'node_modules', 'beaker', 'index.js'))
       })
 
     })
@@ -120,7 +122,7 @@ describe('requireg', function () {
       before(function () {
         resolvers.__set__('rc', function () {
           return {
-            prefix: __dirname + (isWin32 ? '/fixtures/lib' : '/fixtures')
+            prefix: path.join(__dirname, 'fixtures', (isWin32 ? 'lib' : ''))
           }
         })
       })
@@ -135,7 +137,7 @@ describe('requireg', function () {
 
       it('should have the expected module path', function () {
         expect(requiregModule.resolve('beaker'))
-          .to.be.equal(__dirname + '/fixtures/lib/node_modules/beaker/index.js')
+          .to.be.equal(path.join(__dirname, 'fixtures', 'lib', 'node_modules', 'beaker', 'index.js'))
       })
 
     })

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -96,13 +96,11 @@ describe('requireg', function () {
       var rc = require('rc')
 
       before(function () {
-        process.execPath = path.join(__dirname, 'fixtures', 'lib', 'node')
-        resolvers.__set__('rc', function () { return {} })
+        process.execPath = path.join(__dirname, 'fixtures', (isWin32 ? 'lib' : 'bin'), 'node')
       })
 
       after(function () {
         process.execPath = execPath
-        resolvers.__set__('rc', rc)
       })
 
       it('should resolve the beaker package', function () {


### PR DESCRIPTION
- Make tests run on Windows
- Check both prefix and node execution path (allows to resolve packages like npm that are globally installed even when the user has overridden the default prefix). See https://github.com/mjeanroy/bower-npm-resolver/issues/15
- Change default prefix location on Windows to %APPDATA%\npm. Fixes #4 
