### PR TITLE
only check global paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Require and resolve global modules in node/io.js like a boss
 ## Differences with require()
 
 `requireg` tries to find modules in global locations which are
-not natively supported by the node.js [module resolve algorithm][1]. 
+not natively supported by the node.js [module resolve algorithm][1].
 
 Supported locations:
 
@@ -17,7 +17,7 @@ Supported locations:
 
 ## Resolution priority
 
-1. Resolve via native `require()`
+1. Resolve via native `require()` (unless second parameter is true)
 2. User home directory (`$HOME` or `%USERPROFILE%`)
 3. Node installation path
 4. $NODE_MODULES (can have different multiple paths, semicolon separated)
@@ -37,6 +37,14 @@ $ npm install requireg --save[-dev]
 var requireg = require('requireg')
 // require a globally installed package
 var npm = requireg('npm')
+```
+
+### Load only global modules
+
+```js
+var requireg = require('requireg')
+// require a globally installed package and skip local packages
+var eslint = requireg('eslint', true)
 ```
 
 ### Resolve module path
@@ -60,12 +68,12 @@ var globalModule = requireg('npm')
 
 ### Module not found
 
-`requireg` maintains the same behavior as the native `require()`. 
+`requireg` maintains the same behavior as the native `require()`.
 It will throw an `Error` exception if the module was not found
 
 ## Considerations
 
-- Require global modules in node.js are considered anti-pattern. 
+- Require global modules in node.js are considered anti-pattern.
 Note that you can experiment unreliability or inconsistency across different environments.
 I hope you know exactly what you do with `requireg`
 - Only node packages installed with [NPM](https://npmjs.org) are supported (which means only standardized NPM paths are supported)
@@ -82,4 +90,3 @@ Released under MIT license
 [1]: http://nodejs.org/docs/latest/api/modules.html#modules_all_together
 [2]: http://travis-ci.org/h2non/requireg
 [3]: http://badge.fury.io/js/requireg
-

--- a/lib/requireg.js
+++ b/lib/requireg.js
@@ -7,9 +7,9 @@ var NestedError = require('nested-error-stacks')
 
 module.exports = requireg
 
-function requireg(module) {
+function requireg(module, onlyGlobal) {
   try {
-    return require(resolve(module))
+    return require(resolve(module, undefined, onlyGlobal))
   } catch (e) {
     throw new NestedError("Could not require module '"+ module +"'", e)
   }
@@ -21,10 +21,10 @@ requireg.globalize = function () {
   global.requireg = requireg
 }
 
-function resolve(module, dirname) {
+function resolve(module, dirname, onlyGlobal) {
   var i, resolver, modulePath
 
-  for (i = 0, l = resolvers.length; i < l; i += 1) {
+  for (i = (onlyGlobal ? 1 : 0), l = resolvers.length; i < l; i += 1) {
     resolver = resolvers[i]
     if (modulePath = resolver(module, dirname)) {
       break

--- a/lib/requireg.js
+++ b/lib/requireg.js
@@ -1,4 +1,4 @@
-var fs   = require('fs') 
+var fs   = require('fs')
 var path = require('path')
 var resolvers = require('./resolvers')
 var NestedError = require('nested-error-stacks')

--- a/test/requiregSpec.js
+++ b/test/requiregSpec.js
@@ -38,6 +38,14 @@ describe('requireg', function () {
 
   describe('global modules', function () {
 
+    describe('resolve only global', function () {
+
+      it('should not resolve a local module', function () {
+        expect(function () { requiregModule('expect.js', true) }).to.throwError()
+      })
+
+    })
+
     describe('resolve via NODE_PATH', function () {
 
       before(function () {


### PR DESCRIPTION
There should be a way to skip the regular `require()` paths.

see https://github.com/Glavin001/atom-beautify/pull/2147#issuecomment-395269680

In that Atom plugin we are trying to check for a global 'eslint' before using the version packaged with the plugin. Using `requireg` in this case will always use the packaged version first and never actually check for a global version.